### PR TITLE
Fix to: FAQ nav, BLOG heading, minor spelling.

### DIFF
--- a/templates/about.html.ep
+++ b/templates/about.html.ep
@@ -24,7 +24,7 @@
   <section id="timetable" class="section">
     <div class="container">
       <h2 class="title text-center">The Timetable</h2>
-      <p>To satiate public curiosity and accessibilty we are open for walk-ins at the following times:</p>
+      <p>To satiate public curiosity and accessibility we are open for walk-ins at the following times:</p>
 
       <table class="table">
         <thead>
@@ -49,7 +49,7 @@
         </tbody>
       </table>
 
-      <p><b>Note:</b> Non-probabtionary Workshop members have 24/7 access to the space.</p>
+      <p><b>Note:</b> Non-probationary Workshop members have 24/7 access to the space.</p>
     </div>
   </section>
 
@@ -91,7 +91,7 @@
   <section id="association" class="section">
     <div class="container">
       <h2 class="title text-center">The Association</h2>
-      <p>The Ballarat Hackerspace is a volunter based, non-profit incorporated association (in Victoria) and follows the <a href="<%= url_for('modelrules') %>">Rules of Association</a> that it was founded with.</p>
+      <p>The Ballarat Hackerspace is a volunteer based, non-profit incorporated association (in Victoria) and follows the <a href="<%= url_for('modelrules') %>">Rules of Association</a> that it was founded with.</p>
       <p>As part of this, we elect a Committee as chartered in the rules. The current committee were elected on Saturday, 9th of July, 2015.</p>
 
       <table class="table">

--- a/templates/blog.html.ep
+++ b/templates/blog.html.ep
@@ -15,7 +15,7 @@
   <!-- photos section -->
   <section id="team" class="section">
     <div class="container">
-    url_for  <h2 class="title text-center">Blog</h2>
+      <h2 class="title text-center">Blog</h2>
 % if ($tags) {
       <div class="row">
         <div class="col-sm-12">Filtering: <a href="<%= url_for('current')->query([tags => undef]) %>"><i class="fa fa-times"></i></a> <%= $tags %></div>

--- a/templates/faq.html.ep
+++ b/templates/faq.html.ep
@@ -10,7 +10,7 @@
 
 <body>
   <!-- header -->
-  %= include 'navigation-only.inc', active => 'about'
+  %= include 'navigation-only.inc', active => 'faq'
 
   <!-- about team -->
   <section id="team" class="section">

--- a/templates/workshops.html.ep
+++ b/templates/workshops.html.ep
@@ -42,7 +42,7 @@
                 <p>You can print your own tools and toys, learn to work with open source hardware, improve upon publicly available designs, and learn about one of the biggest trends for future development.</p>
                 <p>There are over 100,000 items you can print right now on design-sharing website Thingiverse – all free and able to be customised!</p>
                 <p>If you have ever wanted to get into 3D printing, now is your chance. The Ballarat Hackerspace is presenting a workshop, with all of the necessary components, for you to build your own 3D printer.</p>
-                <p>Our last workshop was a great success and we will defintely be repeating it, just register your interest below to get updates directly to your inbox</p>
+                <p>Our last workshop was a great success and we will definitely be repeating it, just register your interest below to get updates directly to your inbox</p>
 
                 <a href="https://ballarathackerspace.tidyhq.com/signup/new?continue=%2Fpublic%2Fmemberships%2Fnew" class="btn btn-lg btn-cta btn-cta-secondary">Sign up to Register Interest</a>
             </div>


### PR DESCRIPTION
Fixes the following:
 - In the /faq page, previously the nav incorrectly highlighted the "about" page (now fixed).
 - In the /blog page there was a stray "url_for" string, that appeared near the heading (now removed)
 - Fixed a couple of typos across the site.